### PR TITLE
Add 42toolbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ La liste est ouverte à la contribution, n'hésitez donc pas à modifier le fich
 * [Github des Tuteurs](https://github.com/Tuteurs101/) - Des codes reviews, des ressources en rapport avec 42 Lyon, par des studs de 42 Lyon !
 * [42homebrew](https://github.com/kube/42homebrew) - Permet d'installer Homebrew (outil de gestion de paquets pour Mac) sur ta session 42
 * [RP42](https://github.com/alexandregv/RP42) - Rich Presence Discord pour 42 (campus, position, niveau, coalition, etc)
+* [42toolbox](https://github.com/alexandregv/42toolbox) - Boite à outils pour vous faciliter la vie à 42 (docker, valgrind, setup session, etc)
 
 Logiciels et services web
 -------------------------


### PR DESCRIPTION
Toolbox pour 42 qui regroupe plusieurs scripts, par exemple un pour setup Docker à 42 (symlink goinfre etc) et un autre pour libérer de l'espace sur sa session.
Pas mal de monde l'utilise déjà, y compris à 42Lyon.
https://github.com/alexandregv/42toolbox