### PR TITLE
Add Discord 42

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ La liste est ouverte à la contribution, n'hésitez donc pas à modifier le fich
 * [The Matrix](https://the-matrix.le-101.fr/) - La carte des clusters de 42 Lyon !
 * [Intra Tuteurs](https://tuteurs.le-101.fr/) - Blog et intra des tuteurs de 42 Lyon
 * [Github des Tuteurs](https://github.com/Tuteurs101/) - Des codes reviews, des ressources en rapport avec 42 Lyon, par des studs de 42 Lyon !
+* [Discord 42](https://discord.gg/wsrkKE4) - Discord non officiel de 42, pour les curieux, piscineux et étudiants
 * [42homebrew](https://github.com/kube/42homebrew) - Permet d'installer Homebrew (outil de gestion de paquets pour Mac) sur ta session 42
 * [RP42](https://github.com/alexandregv/RP42) - Rich Presence Discord pour 42 (campus, position, niveau, coalition, etc)
 


### PR DESCRIPTION
Le discord compte actuellement 1420 membres, il accueille autant les curieux que les piscineux ou les étudiants.
Il y a plusieurs salons pour les curieux/piscineux (FAQ, salons pour chaque piscines, etc) et un espace réservé aux étudiants (accessible via connexion intra).
Il y a majoritairement des gens de Paris, mais quelques Lyonnais aussi et si on peut en avoir plus c'est parfait!
https://discord.gg/wsrkKE4